### PR TITLE
Fix issue with plotting music lists that contain None

### DIFF
--- a/mai/music_makers.py
+++ b/mai/music_makers.py
@@ -150,6 +150,14 @@ def make_music(pitches=60, durs=0.333, pgm=1, is_drum=False, format='inbrowser',
     else:
         raise ValueError("So sorry but your `format` argument did not match one of the available options")
 
+def n_max(a):
+    '''Return the max of a list that contains None`'''
+    return max(filter(lambda x: x is not None, a))
+
+def n_min(a):
+    '''Return the min of a list that contains None'''
+    return min(filter(lambda x: x is not None, a))
+
 def make_music_plot(pitches=60, durs=0.333, pgm=1, is_drum=False, format='autoplay', sr=16000, figsize=(9,3), cmap='jet', show=True):
     """Plot lists of numbers as music (same API as `make_music`)"""
 
@@ -168,7 +176,7 @@ def make_music_plot(pitches=60, durs=0.333, pgm=1, is_drum=False, format='autopl
     curr_time = 0
     for pitch,dur in zip(pitches, durs):
         if pitch is not None:
-            pitch_normed = float(pitch - min(pitches)) / (max(pitches) - min(pitches)) if (max(pitches) - min(pitches)) != 0 else 1
+            pitch_normed = float(pitch - n_min(pitches)) / (n_max(pitches) - n_min(pitches)) if (n_max(pitches) - n_min(pitches)) != 0 else 1
             plt.scatter([curr_time], [pitch], marker='|', c='white', s=25, zorder=3)
             plt.plot([curr_time, curr_time + dur], [pitch, pitch], lw=5, solid_capstyle='butt', c=cm(pitch_normed), alpha=0.75)
         curr_time += dur

--- a/mai/music_makers.py
+++ b/mai/music_makers.py
@@ -32,9 +32,9 @@ def make_music_heterophonic(pitches=60, durs=0.25, pgm=1, is_drum=False, format=
 
     # which format to render
     if format=='MIDI':
-        return score 
+        return score
     elif format=='audio':
-        return score.fluidsynth(fs=16000) 
+        return score.fluidsynth(fs=16000)
     elif format=='inbrowser':
         return IPython.display.Audio(score.fluidsynth(fs=sr), rate=sr)
     elif format=='autoplay':
@@ -53,16 +53,16 @@ def make_music(pitches=60, durs=0.333, pgm=1, is_drum=False, format='inbrowser',
     """Turn lists of numbers into music.
 
     Converts pitch and duration values into MIDI and/or audio playback. Uses
-    `pretty_midi` for MIDI representation handling, fluidsynth for resynthesis, 
+    `pretty_midi` for MIDI representation handling, fluidsynth for resynthesis,
     and `IPython.display.Audio` for browser playback.
-        
+
     Parameters
     ----------
     pitches : list or scalar
         List of pitches, or scalar if constant pitch. Floating point values are
         interpreted as microtonal pitch deviations.
     durs: list or scalar
-        List of durations, or scalar if constant duration. 
+        List of durations, or scalar if constant duration.
     pgm: number
         MIDI program number, in range ``[0, 127]``.
     is_drum : bool
@@ -70,8 +70,8 @@ def make_music(pitches=60, durs=0.333, pgm=1, is_drum=False, format='inbrowser',
     format : string
         Which format to render sound to?
         - `'MIDI'` returns MIDI as a `pretty_midi` object
-        - `'audio'` returns waveforms as a `numpy` nd.array  
-        - `'inbrowser'` returns `IPython.display.Audio` widget 
+        - `'audio'` returns waveforms as a `numpy` nd.array
+        - `'inbrowser'` returns `IPython.display.Audio` widget
         - `'autoplay'` returns `IPython.display.Audio` widget and plays it
 
     Returns
@@ -80,19 +80,19 @@ def make_music(pitches=60, durs=0.333, pgm=1, is_drum=False, format='inbrowser',
 
     Notes
     -----
-    If len(pitches) and len(durs) do not match, the smaller list is extended to 
+    If len(pitches) and len(durs) do not match, the smaller list is extended to
     match the length of the longer list by repeating the last value.
     """
 
     # check and convert to list if needed
     pitches = pitches if isinstance(pitches, list) else [pitches]
     durs = durs if isinstance(durs, list) else [durs]
-  
+
     # extend short lists if size mismatch
     max_length = max(len(pitches), len(durs))
     pitches += [pitches[-1]] * (max_length - len(pitches))
     durs += [durs[-1]] * (max_length - len(durs))
-  
+
     # create a PrettyMIDI score
     score = pretty_midi.PrettyMIDI(resolution=resolution)
 
@@ -124,7 +124,7 @@ def make_music(pitches=60, durs=0.333, pgm=1, is_drum=False, format='inbrowser',
 
                 # if microtonal
                 if micros != 0:
-                                          
+
                     # create a new pitch bend
                     # note: 4096 is a semitone in standard MIDI +/-2 pitchbend range
                     micropitch = pretty_midi.PitchBend(pitch=int(round(micros*4096)), time=now_time)
@@ -140,9 +140,9 @@ def make_music(pitches=60, durs=0.333, pgm=1, is_drum=False, format='inbrowser',
 
     # which format to render
     if format=='MIDI':
-        return score 
+        return score
     elif format=='audio':
-        return score.fluidsynth(fs=16000) 
+        return score.fluidsynth(fs=16000)
     elif format=='inbrowser':
         return IPython.display.Audio(score.fluidsynth(fs=sr), rate=sr)
     elif format=='autoplay':
@@ -156,7 +156,7 @@ def make_music_plot(pitches=60, durs=0.333, pgm=1, is_drum=False, format='autopl
     # check and convert to list if needed
     pitches = pitches if isinstance(pitches, list) else [pitches]
     durs = durs if isinstance(durs, list) else [durs]
-  
+
     # extend short lists if size mismatch
     max_length = max(len(pitches), len(durs))
     pitches += [pitches[-1]] * (max_length - len(pitches))
@@ -167,9 +167,10 @@ def make_music_plot(pitches=60, durs=0.333, pgm=1, is_drum=False, format='autopl
     cm = plt.cm.get_cmap(name=cmap)
     curr_time = 0
     for pitch,dur in zip(pitches, durs):
-        pitch_normed = float(pitch - min(pitches)) / (max(pitches) - min(pitches)) if (max(pitches) - min(pitches)) != 0 else 1
-        plt.scatter([curr_time], [pitch], marker='|', c='white', s=25, zorder=3)
-        plt.plot([curr_time, curr_time + dur], [pitch, pitch], lw=5, solid_capstyle='butt', c=cm(pitch_normed), alpha=0.75)
+        if pitch is not None:
+            pitch_normed = float(pitch - min(pitches)) / (max(pitches) - min(pitches)) if (max(pitches) - min(pitches)) != 0 else 1
+            plt.scatter([curr_time], [pitch], marker='|', c='white', s=25, zorder=3)
+            plt.plot([curr_time, curr_time + dur], [pitch, pitch], lw=5, solid_capstyle='butt', c=cm(pitch_normed), alpha=0.75)
         curr_time += dur
 
     if show:


### PR DESCRIPTION
In a recent commit, `None` was implemented in `make_music` to represent a rest. However, the `make_music_plot` function was not updated to support these changes. 

This PR fixes the problem by not attempting to plot a value of `None`, and implementing new functions to allow finding the max and min of a list that contains `None`.